### PR TITLE
[🔧] Make sqlite3 dependency stricter (~> 1.3.6)

### DIFF
--- a/lib/eucalypt/core/templates/Gemfile.tt
+++ b/lib/eucalypt/core/templates/Gemfile.tt
@@ -14,7 +14,7 @@ group :test do
 end
 
 # Database adapters
-gem 'sqlite3', '~> 1.3', group: [:development, :test]
+gem 'sqlite3', '~> 1.3.6', group: [:development, :test]
 gem 'pg', '~> 1.0', group: :production
 # ActiveRecord for models and records
 gem 'activerecord', '~> 5.2', require: ['active_support','active_support/core_ext']


### PR DESCRIPTION
The recently released `1.4.0` version for the `sqlite3` gem seems to be causing some loading issues. 

```
Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.0. Make sure all dependencies are added to Gemfile. (LoadError)
```

The current gem version specifier for `sqlite3` (`~> 1.3`) will allow for `1.4.0` to be used - so tightening this restriction to `~> 1.3.6` avoids this LoadError.