### PR TITLE
[🎁] Add 'task' argument to rake command 

### DIFF
--- a/lib/eucalypt/core/cli/rake.rb
+++ b/lib/eucalypt/core/cli/rake.rb
@@ -2,11 +2,11 @@ require_relative '__base__'
 module Eucalypt
   class CLI < Thor
     using Colorize
-    desc "rake", "Run all database migrations".colorize(:grey)
-    def rake
+    desc "rake [TASK]", "Run a rake task".colorize(:grey)
+    def rake(task)
       directory = File.expand_path('.')
       if Eucalypt.app? directory
-        exec "bundle exec rake db:migrate"
+        exec "bundle exec rake #{task}"
       else
         Eucalypt::Error.wrong_directory
       end

--- a/lib/eucalypt/security/namespaces/security-pundit/cli/security-pundit.rb
+++ b/lib/eucalypt/security/namespaces/security-pundit/cli/security-pundit.rb
@@ -64,7 +64,7 @@ module Eucalypt
           inject_into_file(user_model_file, insert, before: /^end/) unless contents.include? insert
         end
 
-        Out.info "Ensure you run `#{'eucalypt rake'.colorize(:bold)}` to create the necessary tables for Pundit."
+        Out.info "Ensure you run `#{'eucalypt rake db:migrate'.colorize(:bold)}` to create the necessary tables for Pundit."
       else
         Eucalypt::Error.wrong_directory
       end

--- a/lib/eucalypt/security/namespaces/security-warden/cli/security-warden.rb
+++ b/lib/eucalypt/security/namespaces/security-warden/cli/security-warden.rb
@@ -64,7 +64,7 @@ module Eucalypt
           auth_controller.generate
         end
 
-        Out.info "Ensure you run `#{'eucalypt rake'.colorize(:bold)}` to create the necessary tables for Warden."
+        Out.info "Ensure you run `#{'eucalypt rake db:migrate'.colorize(:bold)}` to create the necessary tables for Warden."
       else
         Eucalypt::Error.wrong_directory
       end


### PR DESCRIPTION
The `eucalypt rake` command currently runs `bundle exec rake db:migrate` by default.

Although `db:migrate` is the most commonly run rake task in Rails applications, it shouldn't be assumed as the only command. 

This pull request adds a task argument to the `eucalypt rake` command, allowing the user to specify which rake task they wish to run.