### PR TITLE
[patch:git] Add .ruby-version and .ruby-gemset to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,6 @@ Thumbs.db
 ## Other
 /.bundle/
 Gemfile.lock
+.ruby-version
+.ruby-gemset
 .rvmrc


### PR DESCRIPTION
- Add `.ruby-version` and `.ruby-gemset` to `.gitignore`.