### PR TITLE
[patch:lib] Use Regexp#match? instead of =~ to suppress warnings

### DIFF
--- a/lib/eucalypt/helpers/numeric.rb
+++ b/lib/eucalypt/helpers/numeric.rb
@@ -2,7 +2,7 @@ module Eucalypt
   module Helpers
     module Numeric
       def self.string?(string)
-        return true if string =~ /\A\d+\Z/
+        return true if /\A\d+\Z/.match? string
         true if Float(string) rescue false
       end
     end

--- a/lib/eucalypt/helpers/numeric.rb
+++ b/lib/eucalypt/helpers/numeric.rb
@@ -2,8 +2,8 @@ module Eucalypt
   module Helpers
     module Numeric
       def self.string?(string)
-        return true if /\A\d+\Z/.match? string
-        true if Float(string) rescue false
+        return true if /\A\d+\Z/.match? string.to_s
+        true if Float(string.to_s) rescue false
       end
     end
   end


### PR DESCRIPTION
- Use `Regexp#match?` instead of `Object#=~` to suppress warnings when using Ruby `2.6.2`.
- Call `Object#to_s` on `Numeric.string?` argument.