### PR TITLE
[patch:lib] Bundle IRB in Ruby >= 2.6

### DIFF
--- a/lib/eucalypt/core/templates/Gemfile.tt
+++ b/lib/eucalypt/core/templates/Gemfile.tt
@@ -6,6 +6,11 @@ gem 'eucalypt', '<%= config[:version] %>'
 gem 'rake', '~> 12.3'
 gem 'thin', '~> 1.7'
 
+# IRB is not bundled in Ruby >= 2.6
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
+  gem 'irb', require: false
+end
+
 # Test environment
 group :test do
   gem 'rack-test', '~> 1.0', require: 'rack/test'


### PR DESCRIPTION
- Fixed the issue of IRB not being bundled in Ruby `>= 2.6`.<br>_See bundler/bundler#6929._