### PR TITLE
[release] 0.7.1 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.7.1
+
+#### Major changes
+
+- Fixed the issue of IRB not being bundled in Ruby `>= 2.6`.<br>_See bundler/bundler#6929._
+
 # 0.7.0
 
 #### Major changes

--- a/lib/eucalypt/version.rb
+++ b/lib/eucalypt/version.rb
@@ -2,7 +2,7 @@ module Eucalypt
   VERSION = {
     major: 0,
     minor: 7,
-    patch: 0,
+    patch: 1,
     meta: nil
-  }.values.reject(&:nil?).map(&:to_s)*?.
+  }.compact.values.join('.').freeze
 end


### PR DESCRIPTION
# Major changes

- Fixed the issue of IRB not being bundled in Ruby `>= 2.6`.<br>_See bundler/bundler#6929._