### PR TITLE
[patch:lib] Add environment options for 'console' command

### DIFF
--- a/lib/eucalypt/app.rb
+++ b/lib/eucalypt/app.rb
@@ -1,6 +1,11 @@
 module Eucalypt
   APP_FILE = 'Gumfile'.freeze
+
   def self.app?(directory)
     File.exist? File.join(directory, APP_FILE)
+  end
+
+  def self.console?
+    !!ENV['CONSOLE']
   end
 end

--- a/lib/eucalypt/app.rb
+++ b/lib/eucalypt/app.rb
@@ -5,6 +5,8 @@ module Eucalypt
     File.exist? File.join(directory, APP_FILE)
   end
 
+  # @note Does not check for boolean variables.
+  #   Instead checks for presence.
   def self.console?
     !!ENV['CONSOLE']
   end

--- a/lib/eucalypt/core/cli/console.rb
+++ b/lib/eucalypt/core/cli/console.rb
@@ -2,13 +2,34 @@ require_relative '__base__'
 module Eucalypt
   class CLI < Thor
     using Colorize
-    desc "console", "Interactive console with all files loaded".colorize(:grey)
-    def console
+    desc "console [ENV]", "Interactive console with all files loaded".colorize(:grey)
+    def console(env = ENV['APP_ENV']||'development')
       directory = File.expand_path('.')
       if Eucalypt.app? directory
-        exec 'bundle exec irb -r ./app.rb'
+        unless %w[p production d development t test].include? env
+          Out.error "Invalid Rack environment #{env.colorize(:bold)}"
+          return
+        end
+
+        env = map_env env
+        cmd = "CONSOLE=true bundle exec irb -r ./app.rb"
+
+        puts "Running command: #{cmd.colorize(:bold)}"
+        puts "Rack environment: #{env.colorize(:bold)}"
+        exec "env APP_ENV=#{env} #{cmd}"
       else
         Eucalypt::Error.wrong_directory
+      end
+    end
+
+    no_tasks do
+      def map_env(env)
+        case env
+        when ?p then 'production'
+        when ?d then 'development'
+        when ?t then 'test'
+        else env
+        end
       end
     end
   end

--- a/lib/eucalypt/core/templates/eucalypt/config/logging.rb
+++ b/lib/eucalypt/core/templates/eucalypt/config/logging.rb
@@ -11,7 +11,8 @@ class ApplicationController < Sinatra::Base
 
   configure :production do
     enable :logging
-    enable :log_file
+    # Output to log file except when running console
+    set :log_file, !Eucalypt.console?
   end
 
   set :log_directory_format, "%Y-%m-%d_%H-%M-%S"

--- a/spec/eucalypt/app_spec.rb
+++ b/spec/eucalypt/app_spec.rb
@@ -1,28 +1,48 @@
 require 'spec_helper'
 
-describe 'Core application file' do
-  subject { Eucalypt::APP_FILE }
+describe Eucalypt do
+  describe APP_FILE do
+    subject { Eucalypt::APP_FILE }
 
-  context 'should be frozen' do
-    it { expect { subject.gsub! /.*/, '' }.to raise_error FrozenError }
-  end
-end
-
-describe 'Eucalypt.app?' do
-  before { Temporary.create_app }
-  after { Temporary.clear }
-
-  context 'when core application file exists' do
-    it do
-      tmp { expect(Eucalypt.app? '.').to be true }
+    context 'should be frozen' do
+      it { expect { subject.gsub! /.*/, '' }.to raise_error FrozenError }
     end
   end
-  context "when core application file doesn't exist" do
-    it do
-      tmp do
-        FileUtils.rm Eucalypt::APP_FILE
-        expect(Eucalypt.app? '.').to be false
+  describe '.app?' do
+    before { Temporary.create_app }
+    after { Temporary.clear }
+
+    context 'when core application file exists' do
+      it do
+        tmp { expect(Eucalypt.app? '.').to be true }
       end
+    end
+    context "when core application file doesn't exist" do
+      it do
+        tmp do
+          FileUtils.rm Eucalypt::APP_FILE
+          expect(Eucalypt.app? '.').to be false
+        end
+      end
+    end
+  end
+  describe '.console?' do
+    context 'while $CONSOLE is set' do
+      context 'to true' do
+        before { ENV['CONSOLE'] = 'true' }
+
+        it { expect(Eucalypt.console?).to be true }
+      end
+      context 'to false' do
+        before { ENV['CONSOLE'] = 'false' }
+
+        it { expect(Eucalypt.console?).to be true }
+      end
+    end
+    context 'while $CONSOLE is not set' do
+      before { ENV['CONSOLE'] = nil }
+
+      it { expect(Eucalypt.console?).to be false }
     end
   end
 end


### PR DESCRIPTION
- Add environment options for `console` command.
- Add `Eucalypt.console?` to check whether the console is active.
- Redirect console output in production environment to STDOUT by default.