### PR TITLE
[patch:lib] Rescue rspec rake tasks in non-test environments

### DIFF
--- a/lib/eucalypt/core/templates/eucalypt/Procfile
+++ b/lib/eucalypt/core/templates/eucalypt/Procfile
@@ -1,1 +1,2 @@
 web: eucalypt launch production -p $PORT
+release: eucalypt rake db:migrate

--- a/lib/eucalypt/core/templates/eucalypt/Rakefile
+++ b/lib/eucalypt/core/templates/eucalypt/Rakefile
@@ -1,7 +1,9 @@
 require './app'
-require 'rspec/core/rake_task'
 
-task :default => [:spec]
-
-desc "Run the specs"
-RSpec::Core::RakeTask.new :spec
+begin
+  require 'rspec/core/rake_task'
+  task :default => [:spec]
+  desc "Run the specs"
+  RSpec::Core::RakeTask.new :spec
+rescue LoadError
+end


### PR DESCRIPTION
- Rescue `rspec` rake tasks in non-development environments.
- Restore database migration task in `Procfile`.