### PR TITLE
[patch:ci] Change CI script to use implicit rspec call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 before_install: gem update --system
-script: bundle exec rake
+script: bundle exec rspec spec
 rvm:
   - 2.5
   - 2.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,1 @@
 require "bundler/gem_tasks"
-require 'rspec/core/rake_task'
-task :default => [:spec]
-
-desc "Run the specs"
-RSpec::Core::RakeTask.new(:spec)

--- a/lib/eucalypt/core/templates/eucalypt/.travis.yml
+++ b/lib/eucalypt/core/templates/eucalypt/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 before_install: gem update --system
-script: bundle exec rake
+script: bundle exec rspec spec
 rvm: 2.5
 services:
   - postgresql

--- a/lib/eucalypt/core/templates/eucalypt/Rakefile
+++ b/lib/eucalypt/core/templates/eucalypt/Rakefile
@@ -1,9 +1,2 @@
 require './app'
-
-begin
-  require 'rspec/core/rake_task'
-  task :default => [:spec]
-  desc "Run the specs"
-  RSpec::Core::RakeTask.new :spec
-rescue LoadError
-end
+# Add your Rake tasks here!


### PR DESCRIPTION
- Remove `rspec` core rake tasks (top-level & application-level).
- Change CI script to implicit `rspec` call (top-level & application-level).