### PR TITLE
[patch:lib] Modify blog search route regex

### DIFF
--- a/lib/eucalypt/blog/namespaces/blog/templates/controller/controller.tt
+++ b/lib/eucalypt/blog/namespaces/blog/templates/controller/controller.tt
@@ -21,7 +21,7 @@ class BlogController < Eucalypt::Controller(route: '<%= config[:route] %>')
   # Search for blog articles by tag at this route
   get '/search/:tag' do
     @tag = params[:tag]
-    redirect to '/' unless @tag.match /\A[a-zA-Z]*[a-zA-Z0-9\\-_.]*[a-zA-Z0-9]\Z/
+    redirect to '/' unless @tag.match /\A[a-zA-Z0-9]+[a-zA-Z0-9\-_.]*[a-zA-Z0-9]\Z/
     @articles = Blog.search(@tag).sort_by_date order: :descending
     erb :'blog/search', layout: :'layouts/blog/articles'
   end


### PR DESCRIPTION
- **Blog search route regex fixes**: 
  - Un-escape forward slash 
  - Prevent leading hyphens (require leading alphanumeric character)
  - Allow leading integers